### PR TITLE
add support to store which channel a message comes from

### DIFF
--- a/mocks/botMock.js
+++ b/mocks/botMock.js
@@ -9,7 +9,12 @@ class Bot {
         this.apiResponses = new api();
         this.botkit = {
             tasks: [],
-            log: function(){}
+            log: function(){},
+            memory_store: {
+                users: {},
+                channels: {},
+                teams: {}
+            }
         };
         var self = this;
         // this object will store bot answer for each user separately
@@ -30,6 +35,57 @@ class Bot {
 
 
         this.callbacksHashByConvo = {};
+
+        this.botkit.storage = {
+            teams: {
+                get: function(team_id, cb) {
+                    cb(null, self.botkit.memory_store.teams[team_id]);
+                },
+                save: function(team, cb) {
+                    if (team.id) {
+                        self.botkit.memory_store.teams[team.id] = team;
+                        cb(null, team.id);
+                    } else {
+                        cb('No ID specified');
+                    }
+                },
+                all: function(cb) {
+                    cb(null, self.botkit.memory_store.teams);
+                }
+            },
+            users: {
+                get: function(user_id, cb) {
+                    cb(null, self.botkit.memory_store.users[user_id]);
+                },
+                save: function(user, cb) {
+                    if (user.id) {
+                        self.botkit.memory_store.users[user.id] = user;
+                        cb(null, user.id);
+                    } else {
+                        cb('No ID specified');
+                    }
+                },
+                all: function(cb) {
+                    cb(null, self.botkit.memory_store.users);
+                }
+            },
+            channels: {
+                get: function(channel_id, cb) {
+                    cb(null, self.botkit.memory_store.channels[channel_id]);
+                },
+                save: function(channel, cb) {
+                    if (channel.id) {
+                        self.botkit.memory_store.channels[channel.id] = channel;
+                        cb(null, channel.id);
+                    } else {
+                        cb('No ID specified');
+                    }
+                },
+                all: function(cb) {
+                    cb(null, self.botkit.memory_store.channels);
+                }
+            }
+        };
     }
 
     getAPILogByNumber(i) {

--- a/package.json
+++ b/package.json
@@ -2,20 +2,26 @@
   "name": "botkit-mock",
   "version": "0.0.1",
   "description": "mock of botkit lib",
-  "main": "index.js",
+  "main": "mocks/botMock.js",
   "scripts": {
     "test_mocha": "find ./test -name '*MochaSpec.js' | xargs mocha -t 2000 -R spec",
     "test_jasmine": "find ./test -name '*JasmineSpec.js' | xargs jasmine-node"
   },
   "author": "",
   "license": "ISC",
-  "dependencies": {
+  "devDependencies": {
     "assert": "^1.4.1",
     "botkit": "^0.2.2",
     "jasmine-node": "^1.14.5",
     "mocha": "^2.4.5"
   },
   "repository": {
-    "type": "git"
-  }
+    "type": "git",
+    "url": "https://github.com/gratifychat/BotMock.git"
+  },
+  "keywords": [
+    "botkit",
+    "mock"
+  ],
+  "license": "MIT"
 }


### PR DESCRIPTION
we've noticed that botmock stores which user a message comes from, but not which channel it was posted in.  This PR should fix that.