### PR TITLE
Allow matching multiple message types

### DIFF
--- a/mocks/botMock.js
+++ b/mocks/botMock.js
@@ -216,7 +216,10 @@ class Controller {
         var self = this;
         // find action which will handle this message
         var action = self.actions.filter((obj) => {
-            let matchType = obj.type === message.type;
+            if (!Array.isArray(obj.type)) {
+                obj.type = obj.type.split(",");
+            }
+            let matchType = obj.type.indexOf(message.type) > -1;
             // each action has pattern
             let pattern = obj.pattern;
             if (Array.isArray(obj.pattern)) {


### PR DESCRIPTION
Often the type in `.hears` can be multiple things. Botkit supports both arrays of types and comma-separated strings so I've added in basic support for both those situations so the `.hears` still gets triggered when the two types aren't exactly equal. 

Casting to an array as opposed to a string so indexOf will match the whole word only (stops mention and direct_mention being confused). Not sure if there's a more efficient way to do this with regex.